### PR TITLE
 Fix for getTimePosition on ubuntu 14.03

### DIFF
--- a/lib/node-mplayer.js
+++ b/lib/node-mplayer.js
@@ -112,8 +112,15 @@ Mplayer.prototype.getTimeLength = function(callback) {
 
 Mplayer.prototype.getTimePosition = function(callback) {
     if(this.childProc !== null){
+        var that = this;
         this.rl.question("get_time_pos\n", function(answer) {
-            callback(answer.split('=')[1]);
+            if (answer.split('=')[0]=='ANS_TIME_POSITION'){
+                callback(answer.split('=')[1]);
+            }
+            else{
+                // Try again :(
+                that.getTimePosition(callback);
+            }
         });
     }
 };


### PR DESCRIPTION
As the answer from the subprocess sometimes is blank when I poll for the time position, I suggest adding some lines to test the answer.
